### PR TITLE
Add Redux quiz client

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@reduxjs/toolkit": "^2.2.1",
+    "react-redux": "^9.1.0",
+    "axios": "^1.6.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,48 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { useEffect } from 'react'
+import { useAppDispatch, useAppSelector } from './hooks'
+import { startQuiz, submitAnswer, fetchResult } from './features/quiz/quizSlice'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const dispatch = useAppDispatch()
+  const { sessionId, questions, result, status } = useAppSelector((s) => s.quiz)
+
+  useEffect(() => {
+    dispatch(startQuiz())
+  }, [dispatch])
+
+  const handleAnswer = (qId: string, aId: string) => {
+    if (!sessionId) return
+    dispatch(submitAnswer({ sessionId, questionId: qId, answerId: aId }))
+  }
+
+  const handleFinish = () => {
+    if (sessionId) dispatch(fetchResult(sessionId))
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+    <div>
+      <h1>Quiz</h1>
+      {status === 'loading' && <p>Loading...</p>}
+      {questions.map((q) => (
+        <div key={q.id}>
+          <p>{q.text}</p>
+          {q.answers.map((a) => (
+            <button key={a.id} onClick={() => handleAnswer(q.id, a.id)}>
+              {a.text}
+            </button>
+          ))}
+        </div>
+      ))}
+      {sessionId && !result && (
+        <button onClick={handleFinish}>Finish Quiz</button>
+      )}
+      {result && (
         <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+          Score: {result.score} / {result.total}
         </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      )}
+    </div>
   )
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,7 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: 'http://localhost:8000',
+})
+
+export default api

--- a/src/features/quiz/quizSlice.ts
+++ b/src/features/quiz/quizSlice.ts
@@ -1,0 +1,107 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
+import api from '../../api'
+
+export interface AnswerOption {
+  id: string
+  text: string
+}
+
+export interface Question {
+  id: string
+  text: string
+  answers: AnswerOption[]
+}
+
+export interface QuizResult {
+  score: number
+  total: number
+  correctAnswers: Record<string, string>
+}
+
+interface StartQuizResponse {
+  sessionId: string
+  questions: Question[]
+}
+
+interface SubmitAnswerPayload {
+  sessionId: string
+  questionId: string
+  answerId: string
+}
+
+export interface QuizState {
+  sessionId?: string
+  questions: Question[]
+  answers: Record<string, string>
+  result?: QuizResult
+  status: 'idle' | 'loading' | 'error'
+  error?: string
+}
+
+const initialState: QuizState = {
+  questions: [],
+  answers: {},
+  status: 'idle',
+}
+
+export const startQuiz = createAsyncThunk<StartQuizResponse>(
+  'quiz/start',
+  async () => {
+    const { data } = await api.get<StartQuizResponse>('/quiz/start')
+    return data
+  },
+)
+
+export const submitAnswer = createAsyncThunk<
+  { correct: boolean },
+  SubmitAnswerPayload
+>('quiz/answer', async ({ sessionId, questionId, answerId }) => {
+  const { data } = await api.post<{ correct: boolean }>(
+    `/quiz/${sessionId}/answer`,
+    {
+      questionId,
+      answerId,
+    },
+  )
+  return data
+})
+
+export const fetchResult = createAsyncThunk<QuizResult, string>(
+  'quiz/result',
+  async (sessionId) => {
+    const { data } = await api.get<QuizResult>(`/quiz/${sessionId}/result`)
+    return data
+  },
+)
+
+const quizSlice = createSlice({
+  name: 'quiz',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(startQuiz.pending, (state) => {
+        state.status = 'loading'
+        state.error = undefined
+      })
+      .addCase(startQuiz.fulfilled, (state, action) => {
+        state.status = 'idle'
+        state.sessionId = action.payload.sessionId
+        state.questions = action.payload.questions
+        state.answers = {}
+        state.result = undefined
+      })
+      .addCase(startQuiz.rejected, (state, action) => {
+        state.status = 'error'
+        state.error = action.error.message
+      })
+      .addCase(submitAnswer.fulfilled, (state, action) => {
+        // nothing to store from response except maybe correctness
+      })
+      .addCase(fetchResult.fulfilled, (state, action: PayloadAction<QuizResult>) => {
+        state.result = action.payload
+      })
+  },
+})
+
+export default quizSlice.reducer

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import type { RootState, AppDispatch } from './store'
+
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { Provider } from 'react-redux'
+import store from './store'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </StrictMode>,
 )

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit'
+import quizReducer from './features/quiz/quizSlice'
+
+const store = configureStore({
+  reducer: {
+    quiz: quizReducer,
+  },
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+export default store


### PR DESCRIPTION
## Summary
- add axios, redux dependencies
- implement Redux store and hooks
- add quiz slice for API calls
- wire Redux provider and basic quiz UI
- create axios instance for FastAPI backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_68582219090c832b92bf5eb7c6ae36c7